### PR TITLE
SMTP connection class

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,20 @@ try {
 
 $smtp->close();
 ```
+
+## Using an SMTP server
+
+```php
+use peer\mail\transport\SmtpConnection;
+use peer\mail\transport\TransportException;
+
+$smtp= new SmtpConnection('esmtp://user:pass@mail.example.com:25/?auth=login');
+try {
+  $smtp->connect();
+  $smtp->send($msg);
+} catch (TransportException $e) {
+  $e->printStackTrace();
+}
+
+$smtp->close();
+```

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "xp-framework/core": "^8.0 | ^7.0 | ^6.5",
     "xp-framework/text-encode": "^7.0 | ^6.6",
     "xp-framework/networking": "^8.0 | ^7.0 | ^6.6",
+    "xp-framework/logging": "^7.0 | ^6.6",
     "php" : ">=5.5.0"
   },
   "require-dev" : {

--- a/src/main/php/peer/mail/transport/MailTransport.class.php
+++ b/src/main/php/peer/mail/transport/MailTransport.class.php
@@ -1,8 +1,8 @@
 <?php namespace peer\mail\transport;
  
 use text\encode\QuotedPrintable;
+use peer\mail\Message;
 
- 
 /**
  * Mail transport via built-in mail() function
  *
@@ -29,38 +29,21 @@ class MailTransport extends Transport {
    * Connect to this transport
    *
    * @param   string dsn default NULL additional parameters for sendmail
-   * @return  bool success
+   * @return  self
    */
   public function connect($dsn= null) { 
     $this->parameters= $dsn;
-    return true;
+    return $this;
   }
   
-  /**
-   * Close connection
-   *
-   * @return  bool success
-   */
-  public function close() { 
-    return true;
-  }
-
   /**
    * Send a message
    *
    * @param   peer.mail.Message message the Message object to send
    * @return  bool success
    */
-  public function send($message) { 
+  public function send(Message $message) { 
   
-    // Sanity check: Is this a message?
-    if (!$message instanceof \peer\mail\Message) {
-      throw new TransportException(
-        'Can only send messages (given: '.\xp::typeOf($message).')',
-        new \lang\IllegalArgumentException('Parameter message is not a Message object')
-      );
-    }
-    
     // Sanity check: Do we have at least one recipient?
     $to= '';
     for ($i= 0, $s= sizeof($message->to); $i < $s; $i++) {

--- a/src/main/php/peer/mail/transport/SmtpConnection.class.php
+++ b/src/main/php/peer/mail/transport/SmtpConnection.class.php
@@ -45,8 +45,8 @@ class SmtpConnection extends Transport {
    * - smtp://localhost
    * - smtp://localhost:2525
    * - smtp://localhost:25/?helo=hostname.used.in.ehlo
-   * - esmtp://user:pass@smtp.example.com:25/?auth=plain
-   * - esmtp://user:pass@smtp.example.com:25/?auth=login
+   * - esmtp://user:pass@smtp.example.com:25/?auth=[plain,login]
+   * - esmtp://smtp.example.com:25/?starttls=[auto,always,never]
    *
    * @param  string|peer.URL $dsn
    * @param  peer.Socket $socket Used to exchange socket implementation

--- a/src/main/php/peer/mail/transport/SmtpConnection.class.php
+++ b/src/main/php/peer/mail/transport/SmtpConnection.class.php
@@ -209,7 +209,7 @@ class SmtpConnection extends Transport {
       if (false === $this->socket->write($cmd."\r\n")) return false;
 
       // Expecting data?
-      if (null === $expect[0]) return '';
+      if ([] === $expect) return '';
     }
     
     // Read

--- a/src/main/php/peer/mail/transport/SmtpConnection.class.php
+++ b/src/main/php/peer/mail/transport/SmtpConnection.class.php
@@ -1,0 +1,234 @@
+<?php namespace peer\mail\transport;
+ 
+use peer\URL;
+use peer\Socket;
+use peer\ProtocolException;
+use lang\Throwable;
+use lang\IllegalArgumentException;
+use peer\mail\Message;
+
+/**
+ * Mail transport via SMTP
+ *
+ * ```php
+ * $smtp= new SmtpConnection('smtp://localhost:25');
+ * $smtp->setTrace((new LogCategory())->withAppender(new ConsoleAppender()));
+ *
+ * $smtp->connect();
+ * $smtp->send($msg);
+ * $smtp->close();
+ * ```
+ *
+ * @see   rfc://2822
+ * @see   rfc://2554
+ * @see   rfc://1891 SMTP Service Extension for Delivery Status Notifications
+ * @see   http://www.sendmail.org/~ca/email/authrealms.html
+ * @test  xp://peer.mail.unittest.SmtpConnectionTest
+ */
+class SmtpConnection extends Transport {
+  const AUTH_PLAIN = 'plain';
+  const AUTH_LOGIN = 'login';
+
+  private $init, $host, $port, $helo, $socket;
+  private $user, $pass, $auth= null;
+  private $banner= null, $capabilities= [];
+
+  /**
+   * Creates a new SMTP connection
+   *
+   * DSN parameter examples:
+   * 
+   * - smtp://localhost
+   * - smtp://localhost:2525
+   * - smtp://localhost:25/?helo=hostname.used.in.ehlo
+   * - esmtp://user:pass@smtp.example.com:25/?auth=plain
+   * - esmtp://user:pass@smtp.example.com:25/?auth=login
+   *
+   * @param  string|peer.URL $dsn
+   * @throws lang.IllegalArgumentException
+   */
+  public function __construct($dsn, $socket= null) {
+    $u= $dsn instanceof URL ? $dsn : new URL($dsn);
+
+    $this->init= $this->init($u->getScheme());
+    $this->host= $u->getHost();
+    $this->port= $u->getPort(25);
+    $this->helo= $u->getParam('helo', gethostname());
+
+    if ($this->user= $u->getUser()) {
+      $this->pass= $u->getPassword();
+      $this->auth= $this->auth($u->getParam('auth', self::AUTH_PLAIN));
+    }
+
+    $this->socket= $socket ?: new Socket($this->host, $this->port);
+  }
+
+  /** @return string */
+  public function server() { return $this->host.':'.$this->port; }
+
+  /** @return bool */
+  public function connected() { return $this->socket->isConnected(); }
+
+  /** @return string */
+  public function banner() { return $this->banner; }
+
+  /** @return string[] */
+  public function capabilities() { return $this->capabilities; }
+
+  /**
+   * Setup initialization method
+   *
+   * @param  string $scheme
+   * @return function(): void
+   */
+  private function init($scheme) {
+    switch (strtolower($scheme)) {
+      case 'esmtp':
+        return function() {
+          $answer= $this->command('EHLO %s', $this->helo, 250);
+          $this->capabilities= [];
+          while ($answer && $buf= $this->socket->read()) {
+            sscanf($buf, "%d%[^\r]", $code, $capability);
+            $this->trace('+++', $code, $capability);
+            $this->capabilities[]= substr($capability, 1);
+            if ('-' !== $capability{0}) break;
+          }
+        };
+
+      case 'smtp':
+        return function() {
+          $this->command('HELO %s', [$this->helo], 250);
+        };
+
+      default: throw new IllegalArgumentException('Scheme "'.$scheme.'" not supported');
+    }    
+  }
+
+  /**
+   * Setup authentication method
+   *
+   * @param  string $method
+   * @return function(): void
+   */
+  private function auth($method) {
+    switch (strtolower($method)) {
+      case self::AUTH_LOGIN:
+        return function() {
+          $this->command('AUTH LOGIN', [], 334); 
+          $this->command('%s', [base64_encode($this->user)], 334);
+          $this->command('%s', [base64_encode($this->pass)], 235);
+        };
+        
+      case self::AUTH_PLAIN:
+        return function() {
+          $this->command('AUTH PLAIN %s', [base64_encode("\0".$this->user."\0".$this->pass)], 235);
+        };
+        
+      default: throw new IllegalArgumentException('Authentication method '.$method.' not supported');
+    }
+  }
+
+  /**
+   * Private helper method
+   *
+   * @param  string $fmt or NULL to indicate not to write any data
+   * @param  string[] $args arguments for sprintf-string fmt
+   * @param  int|int[] $expect int possible returncodes or NULL to indicate not to read any data
+   * @return string buf
+   */
+  protected function command($fmt, $args, $expect) {
+    if (null === $this->socket) return;
+    
+    $expect= (array)$expect;
+
+    // Send command
+    if (null !== $fmt) {
+      $cmd= vsprintf($fmt, $args);
+      $this->trace('>>>', $cmd);
+      if (false === $this->socket->write($cmd."\r\n")) return false;
+
+      // Expecting data?
+      if (null === $expect[0]) return '';
+    }
+    
+    // Read
+    if (false === ($buf= substr($this->socket->read(), 0, -2))) return false;
+    $this->trace('<<<', $buf);
+    
+    // Got expected data?
+    $code= substr($buf, 0, 3);
+    if (!in_array($code, $expect)) {
+      throw new ProtocolException(
+        'Expected '.implode(' or ', $expect).', have '.$code.' ["'.$buf.'"]'
+      );
+    }
+    
+    return $buf;
+  }
+
+  /**
+   * Connect to this transport
+   *
+   * @return self
+   */
+  public function connect() { 
+    if ($this->socket->isConnected()) return;
+
+    try {
+      $this->socket->connect();
+      $this->banner= substr($this->command(null, [], 220), 4);
+      if ($f= $this->init) $f();
+      if ($f= $this->auth) $f();
+    } catch (Throwable $e) {
+      $this->socket->close();
+      throw new TransportException('Connect failed', $e);
+    }
+
+    return $this;
+  }
+
+  /**
+   * Close connection
+   *
+   * @return void
+   */
+  public function close() {
+    if (!$this->socket->isConnected()) return;
+
+    try {
+      $this->socket->write("QUIT\r\n"); 
+      $this->socket->close();
+    } catch (Throwable $e) {
+      // Ignore
+    }
+  }
+
+  /**
+   * Send a message
+   *
+   * @param  peer.mail.Message $message
+   * @return bool success
+   * @throws peer.mail.TransportException
+   */
+  public function send(Message $message) {
+    try {
+      $this->command('MAIL FROM: %s', $message->from->getAddress(), 250);
+      foreach ([TO, CC, BCC] as $type) {
+        foreach ($message->getRecipients($type) as $r) {
+          $this->command('RCPT TO: %s', $r->getAddress(), [250, 251]);
+        }
+      }
+
+      // Content: Headers and body. Make sure lines containing a dot by itself are
+      // properly escaped.
+      $this->command('DATA', [], 354);
+      $this->command('%s', [$message->getHeaderString()], null);
+      $this->command('%s', [preg_replace('/(^|[\r\n])([\.]+)([\r\n]|$)/', '$1.$2$3', $message->getBody())], null);
+      $this->command('.', [], 250);
+    } catch (Throwable $e) {
+      throw new TransportException('Sending message failed', $e);
+    }
+    
+    return true;
+  }
+}

--- a/src/main/php/peer/mail/transport/SmtpConnection.class.php
+++ b/src/main/php/peer/mail/transport/SmtpConnection.class.php
@@ -167,7 +167,9 @@ class SmtpConnection extends Transport {
       return;
     }
 
-    throw new ProtocolException('Could not negotiate a TLS session');
+    $e= new ProtocolException('Could not negotiate a TLS session');
+    \xp::gc(__FILE__);
+    throw $e;
   }
 
   /**

--- a/src/main/php/peer/mail/transport/SmtpConnection.class.php
+++ b/src/main/php/peer/mail/transport/SmtpConnection.class.php
@@ -137,8 +137,6 @@ class SmtpConnection extends Transport {
    * @return string buf
    */
   protected function command($fmt, $args, $expect) {
-    if (null === $this->socket) return;
-    
     $expect= (array)$expect;
 
     // Send command

--- a/src/main/php/peer/mail/transport/SmtpConnection.class.php
+++ b/src/main/php/peer/mail/transport/SmtpConnection.class.php
@@ -45,6 +45,7 @@ class SmtpConnection extends Transport {
    * - esmtp://user:pass@smtp.example.com:25/?auth=login
    *
    * @param  string|peer.URL $dsn
+   * @param  peer.Socket $socket Used to exchange socket implementation
    * @throws lang.IllegalArgumentException
    */
   public function __construct($dsn, $socket= null) {

--- a/src/main/php/peer/mail/transport/Transport.class.php
+++ b/src/main/php/peer/mail/transport/Transport.class.php
@@ -1,49 +1,49 @@
 <?php namespace peer\mail\transport;
  
 use util\log\Traceable;
-
+use util\log\LogCategory;
+use peer\mail\Message;
+use lang\IllegalArgumentException;
 
 /**
  * Abstract base class for mail transport
- *
- * @purpose  Provide an interface
  */
-abstract class Transport extends \lang\Object implements Traceable {
-  public
-    $cat    = null;
+abstract class Transport implements Traceable, \lang\Closeable {
+  public $cat= null;
 
   /**
    * Connect to this transport
    *
-   * @param   string dsn default NULL
+   * @return self
    */
-  public function connect($dsn= null) { }
+  public function connect() { return $this; }
   
   /**
    * Close connection
    *
+   * @return void
    */
   public function close() { }
 
   /**
    * Send a message
    *
-   * @param   peer.mail.Message message the Message object to send
-   * @throws  peer.mail.transport.TransportException to indicate an error occured
+   * @param  peer.mail.Message $message
+   * @return bool success
+   * @throws peer.mail.TransportException
    */
-  public abstract function send($message);
+  public abstract function send(Message $message);
   
   /**
    * Set a LogCategory for tracing communication
    *
-   * @param   util.log.LogCategory cat a LogCategory object to which communication
-   *          information will be passed to or NULL to stop tracing
-   * @return  util.log.LogCategory
-   * @throws  lang.IllegalArgumentException in case a of a type mismatch
+   * @param  util.log.LogCategory $cat pass NULL to stop tracing
+   * @return void
+   * @throws lang.IllegalArgumentException in case a of a type mismatch
    */
   public function setTrace($cat) {
-    if (null !== $cat && !$cat instanceof \util\log\LogCategory) {
-      throw new \lang\IllegalArgumentException('Argument passed is not a LogCategory');
+    if (null !== $cat && !$cat instanceof LogCategory) {
+      throw new IllegalArgumentException('Expected a LogCategory, have '.\xp::typeOf($cat));
     }
     
     $this->cat= $cat;
@@ -52,12 +52,12 @@ abstract class Transport extends \lang\Object implements Traceable {
   /**
    * Trace function
    *
-   * @param   var* arguments
+   * @param  var... arguments
+   * @return void
    */
   protected function trace() {
-    if (null == $this->cat) return;
+    if (null === $this->cat) return;
     $args= func_get_args();
     call_user_func_array([$this->cat, 'debug'], $args);
   }
-
-} 
+}

--- a/src/test/php/peer/mail/unittest/SmtpConnectionTest.class.php
+++ b/src/test/php/peer/mail/unittest/SmtpConnectionTest.class.php
@@ -1,0 +1,225 @@
+<?php namespace peer\mail\unittest;
+
+use lang\FormatException;
+use lang\IllegalArgumentException;
+use peer\mail\transport\SmtpConnection;
+use peer\mail\transport\TransportException;
+use peer\URL;
+use peer\Socket;
+use peer\SocketException;
+
+class SmtpConnectionTest extends \unittest\TestCase {
+
+  #[@test, @values([
+  #  'smtp://smtp.example.com',
+  #  'smtp://smtp.example.com:2525',
+  #  'esmtp://user:pass@smtp.example.com:25/?auth=plain',
+  #  'esmtp://user:pass@smtp.example.com:25/?auth=login'
+  #])]
+  public function can_create_with($dsn) {
+    new SmtpConnection($dsn);
+  }
+
+  #[@test]
+  public function can_create_with_url() {
+    new SmtpConnection(new URL('smtp://localhost'));
+  }
+
+  #[@test, @expect(FormatException::class), @values([
+  #  '',
+  #  'localhost:25',
+  #  'smtp://'
+  #])]
+  public function malformed($dsn) {
+    new SmtpConnection($dsn);
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function unsupported_scheme() {
+    new SmtpConnection('http://localhost:25');
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function unsupported_authentication() {
+    new SmtpConnection('smtp://user:pass@localhost:25/?auth=illegal');
+  }
+
+  #[@test, @values([
+  #  'smtp://smtp.example.com',
+  #  'smtp://smtp.example.com:25',
+  #  'esmtp://user:pass@smtp.example.com/?auth=plain',
+  #  'esmtp://user:pass@smtp.example.com:25/?auth=login'
+  #])]
+  public function server($dsn) {
+    $this->assertEquals('smtp.example.com:25', (new SmtpConnection($dsn))->server());
+  }
+
+  #[@test]
+  public function intially_not_connected() {
+    $this->assertFalse((new SmtpConnection('smtp://test'))->connected());
+  }
+
+  #[@test]
+  public function connected() {
+    $answers= [
+      '220 test (mreue101) ESMTP Service ready',
+      '250 test Hello tester'
+    ];
+    $conn= new SmtpConnection('smtp://test?helo=tester', newinstance(Socket::class, ['test', 25], [
+      'connected'   => false,
+      'isConnected' => function() { return $this->connected; },
+      'connect'     => function($timeout= 2) { $this->connected= true; },
+      'close'       => function() { $this->connected= false; },
+      'read'        => function($n= 8192) use(&$answers) { return array_shift($answers)."\r\n"; },
+      'write'       => function($bytes) { }
+    ]));
+    $conn->connect();
+    $this->assertTrue($conn->connected());
+  }
+
+  #[@test, @expect(TransportException::class)]
+  public function connection_failed() {
+    $conn= new SmtpConnection('smtp://test?helo=tester', newinstance(Socket::class, ['test', 25], [
+      'isConnected' => function() { return false; },
+      'connect'     => function($timeout= 2) { throw new SocketException('Cannot connect'); },
+      'close'       => function() { },
+      'read'        => function($n= 8192) { },
+      'write'       => function($bytes) { }
+    ]));
+    $conn->connect();
+  }
+
+  #[@test]
+  public function smtp_dialog() {
+    $commands= [];
+    $answers= [
+      '220 test (mreue101) ESMTP Service ready',
+      '250 test Hello tester'
+    ];
+    $conn= new SmtpConnection('smtp://test?helo=tester', newinstance(Socket::class, ['test', 25], [
+      'connected'   => false,
+      'isConnected' => function() { return $this->connected; },
+      'connect'     => function($timeout= 2) { $this->connected= true; },
+      'close'       => function() { $this->connected= false; },
+      'read'        => function($n= 8192) use(&$answers) { return array_shift($answers)."\r\n"; },
+      'write'       => function($bytes) use(&$commands) { $commands[]= rtrim($bytes, "\r\n"); }
+    ]));
+    $conn->connect();
+    $conn->close();
+
+    $this->assertEquals(['HELO tester', 'QUIT'], $commands);
+    $this->assertEquals('test (mreue101) ESMTP Service ready', $conn->banner());
+    $this->assertEquals([], $conn->capabilities());
+  }
+
+  #[@test]
+  public function esmtp_dialog() {
+    $commands= [];
+    $answers= [
+      '220 test (mreue101) ESMTP Service ready',
+      '250-test Hello tester',
+      '250-SIZE 69920427',
+      '250-AUTH LOGIN PLAIN',
+      '250 STARTTLS'
+    ];
+    $conn= new SmtpConnection('esmtp://test?helo=tester', newinstance(Socket::class, ['test', 25], [
+      'connected'   => false,
+      'isConnected' => function() { return $this->connected; },
+      'connect'     => function($timeout= 2) { $this->connected= true; },
+      'close'       => function() { $this->connected= false; },
+      'read'        => function($n= 8192) use(&$answers) { return array_shift($answers)."\r\n"; },
+      'write'       => function($bytes) use(&$commands) { $commands[]= rtrim($bytes, "\r\n"); }
+    ]));
+    $conn->connect();
+    $conn->close();
+
+    $this->assertEquals(['EHLO tester', 'QUIT'], $commands);
+    $this->assertEquals('test (mreue101) ESMTP Service ready', $conn->banner());
+    $this->assertEquals(['SIZE 69920427', 'AUTH LOGIN PLAIN', 'STARTTLS'], $conn->capabilities());
+  }
+
+  #[@test]
+  public function auth_plain() {
+    $commands= [];
+    $answers= [
+      '220 test (mreue101) ESMTP Service ready',
+      '250-test Hello tester',
+      '250 AUTH LOGIN PLAIN',
+      '235 Authenticated'
+    ];
+    $conn= new SmtpConnection('esmtp://user:pass@test?auth=plain&helo=tester', newinstance(Socket::class, ['test', 25], [
+      'connected'   => false,
+      'isConnected' => function() { return $this->connected; },
+      'connect'     => function($timeout= 2) { $this->connected= true; },
+      'close'       => function() { $this->connected= false; },
+      'read'        => function($n= 8192) use(&$answers) { return array_shift($answers)."\r\n"; },
+      'write'       => function($bytes) use(&$commands) { $commands[]= rtrim($bytes, "\r\n"); }
+    ]));
+    $conn->connect();
+    $conn->close();
+
+    $this->assertEquals(['EHLO tester', 'AUTH PLAIN AHVzZXIAcGFzcw==', 'QUIT'], $commands);
+  }
+
+  #[@test]
+  public function auth_login() {
+    $commands= [];
+    $answers= [
+      '220 test (mreue101) ESMTP Service ready',
+      '250-test Hello tester',
+      '250 AUTH LOGIN PLAIN',
+      '334 VXNlcm5hbWU6',
+      '334 UGFzc3dvcmQ6',
+      '235 Authenticated'
+    ];
+    $conn= new SmtpConnection('esmtp://user:pass@test?auth=login&helo=tester', newinstance(Socket::class, ['test', 25], [
+      'connected'   => false,
+      'isConnected' => function() { return $this->connected; },
+      'connect'     => function($timeout= 2) { $this->connected= true; },
+      'close'       => function() { $this->connected= false; },
+      'read'        => function($n= 8192) use(&$answers) { return array_shift($answers)."\r\n"; },
+      'write'       => function($bytes) use(&$commands) { $commands[]= rtrim($bytes, "\r\n"); }
+    ]));
+    $conn->connect();
+    $conn->close();
+
+    $this->assertEquals(['EHLO tester', 'AUTH LOGIN', 'dXNlcg==', 'cGFzcw==', 'QUIT'], $commands);
+  }
+
+  #[@test, @expect(TransportException::class)]
+  public function dialog_refused() {
+    $commands= [];
+    $answers= [
+      '500 I do not like you'
+    ];
+    $conn= new SmtpConnection('smtp://test?helo=tester', newinstance(Socket::class, ['test', 25], [
+      'connected'   => false,
+      'isConnected' => function() { return $this->connected; },
+      'connect'     => function($timeout= 2) { $this->connected= true; },
+      'close'       => function() { $this->connected= false; },
+      'read'        => function($n= 8192) use(&$answers) { return array_shift($answers)."\r\n"; },
+      'write'       => function($bytes) use(&$commands) { $commands[]= rtrim($bytes, "\r\n"); }
+    ]));
+    $conn->connect();
+  }
+
+  #[@test, @expect(TransportException::class)]
+  public function authentication_refused() {
+    $commands= [];
+    $answers= [
+      '220 test (mreue101) ESMTP Service ready',
+      '250-test Hello tester',
+      '250 AUTH LOGIN PLAIN',
+      '535 Authentication credentials invalid'
+    ];
+    $conn= new SmtpConnection('esmtp://user:pass@test?helo=tester', newinstance(Socket::class, ['test', 25], [
+      'connected'   => false,
+      'isConnected' => function() { return $this->connected; },
+      'connect'     => function($timeout= 2) { $this->connected= true; },
+      'close'       => function() { $this->connected= false; },
+      'read'        => function($n= 8192) use(&$answers) { return array_shift($answers)."\r\n"; },
+      'write'       => function($bytes) use(&$commands) { $commands[]= rtrim($bytes, "\r\n"); }
+    ]));
+    $conn->connect();
+  }
+}

--- a/src/test/php/peer/mail/unittest/SmtpConnectionTest.class.php
+++ b/src/test/php/peer/mail/unittest/SmtpConnectionTest.class.php
@@ -249,4 +249,24 @@ class SmtpConnectionTest extends \unittest\TestCase {
     ]));
     $conn->connect();
   }
+
+  #[@test, @expect(TransportException::class)]
+  public function starttls_failure() {
+    $commands= [];
+    $answers= [
+      '220 test (mreue101) ESMTP Service ready',
+      '250-test Hello tester',
+      '250 STARTTLS',
+      '220 Go ahead'
+    ];
+    $conn= new SmtpConnection('esmtp://test?helo=tester', newinstance(Socket::class, ['test', 25], [
+      'connected'   => false,
+      'isConnected' => function() { return $this->connected; },
+      'connect'     => function($timeout= 2) { $this->connected= true; },
+      'close'       => function() { $this->connected= false; },
+      'read'        => function($n= 8192) use(&$answers) { return array_shift($answers)."\r\n"; },
+      'write'       => function($bytes) use(&$commands) { $commands[]= rtrim($bytes, "\r\n"); }
+    ]));
+    $conn->connect();
+  }
 }

--- a/src/test/php/peer/mail/unittest/SmtpConnectionTest.class.php
+++ b/src/test/php/peer/mail/unittest/SmtpConnectionTest.class.php
@@ -7,6 +7,7 @@ use peer\mail\transport\TransportException;
 use peer\URL;
 use peer\Socket;
 use peer\SocketException;
+use unittest\actions\VerifyThat;
 
 class SmtpConnectionTest extends \unittest\TestCase {
 
@@ -230,7 +231,9 @@ class SmtpConnectionTest extends \unittest\TestCase {
     $conn->connect();
   }
 
-  #[@test, @expect(TransportException::class)]
+  #[@test, @expect(TransportException::class), @action(new VerifyThat(function() {
+  #  return function_exists('stream_socket_enable_crypto');
+  #}))]
   public function starttls_refused() {
     $commands= [];
     $answers= [
@@ -250,7 +253,9 @@ class SmtpConnectionTest extends \unittest\TestCase {
     $conn->connect();
   }
 
-  #[@test, @expect(TransportException::class)]
+  #[@test, @expect(TransportException::class), @action(new VerifyThat(function() {
+  #  return function_exists('stream_socket_enable_crypto');
+  #}))]
   public function starttls_failure() {
     $commands= [];
     $answers= [

--- a/src/test/php/peer/mail/unittest/SmtpConnectionTest.class.php
+++ b/src/test/php/peer/mail/unittest/SmtpConnectionTest.class.php
@@ -14,7 +14,10 @@ class SmtpConnectionTest extends \unittest\TestCase {
   #  'smtp://smtp.example.com',
   #  'smtp://smtp.example.com:2525',
   #  'esmtp://user:pass@smtp.example.com:25/?auth=plain',
-  #  'esmtp://user:pass@smtp.example.com:25/?auth=login'
+  #  'esmtp://user:pass@smtp.example.com:25/?auth=login',
+  #  'esmtp://user:pass@smtp.example.com:25/?starttls=never',
+  #  'esmtp://user:pass@smtp.example.com:25/?starttls=auto',
+  #  'esmtp://user:pass@smtp.example.com:25/?starttls=always'
   #])]
   public function can_create_with($dsn) {
     new SmtpConnection($dsn);
@@ -42,6 +45,11 @@ class SmtpConnectionTest extends \unittest\TestCase {
   #[@test, @expect(IllegalArgumentException::class)]
   public function unsupported_authentication() {
     new SmtpConnection('smtp://user:pass@localhost:25/?auth=illegal');
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function unsupported_starttls() {
+    new SmtpConnection('esmtp://localhost:25/?starttls=illegal');
   }
 
   #[@test, @values([


### PR DESCRIPTION
This pull request adds a new SmtpConnection class which replaces SmtpTransport. The new class expects the DSN as constructor parameter instead of it being passed to connect(). It also supports encryption using STARTTLS by default or SMTPS if explicitely stated.
### Example

``` php
use peer\mail\transport\SmtpConnection;
use peer\mail\transport\TransportException;

$smtp= new SmtpConnection('esmtp://user:pass@mail.example.com:25/?auth=login');
try {
  $smtp->connect();
  $smtp->send($msg);
} catch (TransportException $e) {
  $e->printStackTrace();
}

$smtp->close();
```
### DSNs
- `smtp://localhost` - Port defaults to 25
- `smtp://localhost:2525` - ...but may be overridden
- `smtp://localhost:25/?helo=hostname.used.in.ehlo` - Defaults to [gethostname()](http://php.net/gethostname)
- `esmtp://user:pass@smtp.example.com:25/?auth=[plain,login]` - Defaults to plain
- `esmtp://smtp.example.com:25/?starttls=[auto,always,never]` - Defaults to auto
- `smtps[+v2|+v3|+tls]://localhost:587` - Defaults to STREAM_CRYPTO_METHOD_SSLv23_CLIENT
- `esmtps[+v2|+v3|+tls]://localhost` - SSL Port defaults to 587
