### PR TITLE
XP9 Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: php
 dist: trusty
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,9 @@ matrix:
     - php: nightly
 
 before_script:
-  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v6.3.0/setup' -O - | php
+  - curl -sSL https://dl.bintray.com/xp-runners/generic/xp-run-master.sh > xp-run
   - composer install --prefer-dist
   - echo "vendor/autoload.php" > composer.pth
-  - echo "use=vendor/xp-framework/core" > xp.ini
-  - echo "[runtime]" >> xp.ini
-  - echo "date.timezone=Europe/Berlin" >> xp.ini
 
 script:
-  - ./unittest src/test/php
+  - sh xp-run xp.unittest.TestRunner src/test/php

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,11 @@ E-Mail APIs, POP3, IMAP, MailDir, SMTP support for the XP Framework ChangeLog
 
 ## ?.?.? / ????-??-??
 
+## 8.0.0 / 2017-06-19
+
+* **Heads up:** Drop PHP 5.5 support - @thekid
+* Added forward compatibility with XP 9.0.0 - @thekid
+
 ## 7.3.3 / 2017-05-20
 
 * Refactored code to use `typeof()` instead of `xp::typeOf()`, see

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Mail for XP
 [![Build Status on TravisCI](https://secure.travis-ci.org/xp-framework/mail.svg)](http://travis-ci.org/xp-framework/mail)
 [![XP Framework Module](https://raw.githubusercontent.com/xp-framework/web/master/static/xp-framework-badge.png)](https://github.com/xp-framework/core)
 [![BSD Licence](https://raw.githubusercontent.com/xp-framework/web/master/static/licence-bsd.png)](https://github.com/xp-framework/core/blob/master/LICENCE.md)
-[![Required PHP 5.5+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-5_5plus.png)](http://php.net/)
+[![Required PHP 5.6+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-5_6plus.png)](http://php.net/)
 [![Supports PHP 7.0+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-7_0plus.png)](http://php.net/)
 [![Supports HHVM 3.4+](https://raw.githubusercontent.com/xp-framework/web/master/static/hhvm-3_4plus.png)](http://hhvm.com/)
 [![Latest Stable Version](https://poser.pugx.org/xp-framework/mail/version.png)](https://packagist.org/packages/xp-framework/mail)

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "xp-framework/text-encode": "^7.0 | ^6.6",
     "xp-framework/networking": "^8.0 | ^7.0 | ^6.6",
     "xp-framework/logging": "^7.0 | ^6.6",
-    "php" : ">=5.5.0"
+    "php" : ">=5.6.0"
   },
   "require-dev" : {
     "xp-framework/unittest": "^7.0 | ^6.5"

--- a/composer.json
+++ b/composer.json
@@ -6,14 +6,14 @@
   "description" : "Mail for XP",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^8.0 | ^7.0 | ^6.5",
-    "xp-framework/text-encode": "^7.0 | ^6.6",
-    "xp-framework/networking": "^8.0 | ^7.0 | ^6.6",
-    "xp-framework/logging": "^7.0 | ^6.6",
+    "xp-framework/core": "^9.0 | ^8.0 | ^7.0 | ^6.5",
+    "xp-framework/text-encode": "^8.0 | ^7.0 | ^6.6",
+    "xp-framework/networking": "^9.0 | ^8.0 | ^7.0 | ^6.6",
+    "xp-framework/logging": "^8.0 | ^7.0 | ^6.6",
     "php" : ">=5.6.0"
   },
   "require-dev" : {
-    "xp-framework/unittest": "^7.0 | ^6.5"
+    "xp-framework/unittest": "^8.0 | ^7.0 | ^6.5"
   },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "php" : ">=5.6.0"
   },
   "require-dev" : {
-    "xp-framework/unittest": "^8.0 | ^7.0 | ^6.5"
+    "xp-framework/unittest": "^9.0 | ^8.0 | ^7.0 | ^6.5"
   },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]

--- a/src/main/php/peer/mail/InternetAddress.class.php
+++ b/src/main/php/peer/mail/InternetAddress.class.php
@@ -2,6 +2,7 @@
  
 use text\encode\QuotedPrintable;
 use text\encode\Base64;
+use lang\Value;
  
 /**
  * Internet address
@@ -12,7 +13,7 @@ use text\encode\Base64;
  * @see       rfc://2822
  * @see       rfc://2822#3.4.1
  */
-class InternetAddress implements MessagingAddress {
+class InternetAddress implements MessagingAddress, Value {
   public 
     $personal  = '',
     $localpart = '',
@@ -50,19 +51,6 @@ class InternetAddress implements MessagingAddress {
    */
   public function hashCode() {
     return md5($this->localpart.'@'.$this->domain);
-  }
-  
-  /**
-   * Retrieve whether another object is equal to this
-   *
-   * @param   lang.Object cmp
-   * @return  bool
-   */
-  public function equals($cmp) {
-    return (
-      $cmp instanceof InternetAddress and 
-      $this->personal.$this->localpart.$this->domain === $cmp->personal.$cmp->localpart.$cmp->domain
-    );
   }
   
   /**
@@ -131,5 +119,21 @@ class InternetAddress implements MessagingAddress {
       empty($this->personal) ? '' : 
       QuotedPrintable::encode(iconv(\xp::ENCODING, $charset, $this->personal), $charset).' '
     ).'<'.$this->localpart.'@'.$this->domain.'>';
+  }
+
+  /**
+   * Compares this address to a given value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self
+      ? strcmp(
+        $this->personal.' <'.$this->localpart.'@'.$this->domain.'>',
+        $value->personal.' <'.$value->localpart.'@'.$value->domain.'>'
+      )
+      : 1
+    ;
   }
 }

--- a/src/main/php/peer/mail/InternetAddress.class.php
+++ b/src/main/php/peer/mail/InternetAddress.class.php
@@ -2,7 +2,6 @@
  
 use text\encode\QuotedPrintable;
 use text\encode\Base64;
-
  
 /**
  * Internet address
@@ -12,9 +11,8 @@ use text\encode\Base64;
  * @see       http://www.cs.tut.fi/~jkorpela/rfc/822addr.html
  * @see       rfc://2822
  * @see       rfc://2822#3.4.1
- * @purpose   Represents an Internet address
  */
-class InternetAddress extends \lang\Object implements MessagingAddress {
+class InternetAddress implements MessagingAddress {
   public 
     $personal  = '',
     $localpart = '',

--- a/src/main/php/peer/mail/MailFolder.class.php
+++ b/src/main/php/peer/mail/MailFolder.class.php
@@ -1,13 +1,11 @@
 <?php namespace peer\mail;
- 
-
 
 /**
  * Mail folder
  *
  * @purpose  Wrap
  */
-class MailFolder extends \lang\Object {
+class MailFolder {
   public
     $name  = '',
     $store = null;
@@ -23,8 +21,7 @@ class MailFolder extends \lang\Object {
    */  
   public function __construct($store, $name= '') {
     $this->name= $name;
-    $this->store= $store;
-    
+    $this->store= $store; 
   }
 
   /**

--- a/src/main/php/peer/mail/Message.class.php
+++ b/src/main/php/peer/mail/Message.class.php
@@ -62,9 +62,8 @@ define('HEADER_RETURNPATH',   'Return-Path');
  * @see      xp://peer.mail.MimeMessage
  * @see      xp://peer.mail.transport.Transport
  * @test     xp://net.xp_framework.unittest.peer.mail.MessageTest
- * @purpose  Provide a basic e-mail message (single-part)
  */
-class Message extends \lang\Object {
+class Message {
   public 
     $headers          = [],
     $body             = '',

--- a/src/main/php/peer/mail/MimePart.class.php
+++ b/src/main/php/peer/mail/MimePart.class.php
@@ -19,7 +19,7 @@ define('MIME_ENC_7BIT',       '7bit');
  * @test  xp://peer.mail.unittest.MimePartTest
  * @see   rfc://1521
  */
-class MimePart extends \lang\Object {
+class MimePart {
   public
     $contenttype      = '',
     $charset          = '',

--- a/src/main/php/peer/mail/store/MailStore.class.php
+++ b/src/main/php/peer/mail/store/MailStore.class.php
@@ -2,7 +2,6 @@
  
 use peer\mail\MessagingException;
 use peer\mail\MailFolder;
-
  
 /**
  * An abstract class that models a message store and its access protocol, 
@@ -35,7 +34,7 @@ use peer\mail\MailFolder;
  * @see      xp://peer.mail.MailFolder
  * @purpose  Interface for different MailStores
  */
-class MailStore extends \lang\Object {
+class MailStore {
   public 
     $_hdl  = null,
     $cache = null;

--- a/src/main/php/peer/mail/store/StoreCache.class.php
+++ b/src/main/php/peer/mail/store/StoreCache.class.php
@@ -13,9 +13,8 @@ define('SKEY_PART',     'part.');
  * @see      xp://peer.mail.MailStore
  * @purpose  Provide an API for caching of MailStore objects
  */
-class StoreCache extends \lang\Object {
-  public
-    $data = [];
+class StoreCache {
+  public $data= [];
   
   /**
    * Create string representation, e.g.

--- a/src/main/php/peer/mail/util/FilesystemImageLoader.class.php
+++ b/src/main/php/peer/mail/util/FilesystemImageLoader.class.php
@@ -4,13 +4,12 @@ use io\File;
 use io\FileUtil;
 use util\MimeType;
 
-
 /**
  * Loads images from the filesystem
  *
  * @purpose  ImageLoader
  */
-class FilesystemImageLoader extends \lang\Object implements ImageLoader {
+class FilesystemImageLoader implements ImageLoader {
 
   /**
    * Load an image
@@ -24,5 +23,4 @@ class FilesystemImageLoader extends \lang\Object implements ImageLoader {
       MimeType::getByFilename($source->getURL())
     ];
   }
-
 } 


### PR DESCRIPTION
This pull request makes this library compatible with XP9 and the following upcoming versions:

* [x] xp-framework/text-encode [8.0](https://github.com/xp-framework/text-encode/releases/tag/v8.0.0)+ 
* [x] xp-framework/networking [9.0](https://github.com/xp-framework/networking/releases/tag/v9.0.0)+ 
* [x] xp-framework/logging [8.0](https://github.com/xp-framework/logging/releases/tag/v8.0.0)+
* [x] xp-framework/unittest [9.0](https://github.com/xp-framework/unittest/releases/tag/v9.0.0)+ 